### PR TITLE
Update ContinueProcessOperation.java

### DIFF
--- a/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
+++ b/modules/flowable-engine/src/main/java/org/flowable/engine/impl/agenda/ContinueProcessOperation.java
@@ -395,6 +395,12 @@ public class ContinueProcessOperation extends AbstractOperation {
 
             while (boundaryEventsIterator.hasNext() && boundaryEventExecutionsIterator.hasNext()) {
                 BoundaryEvent boundaryEvent = boundaryEventsIterator.next();
+                if (!(boundaryEvent.getBehavior() instanceof BoundaryEventRegistryEventActivityBehavior)) {
+                    if (CollectionUtil.isEmpty(boundaryEvent.getEventDefinitions())
+                            || (boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition)) {
+                        continue;
+                    }
+                }
                 ExecutionEntity boundaryEventExecution = boundaryEventExecutionsIterator.next();
                 ActivityBehavior boundaryEventBehavior = ((ActivityBehavior) boundaryEvent.getBehavior());
                 LOGGER.debug("Executing boundary event activityBehavior {} with execution {}", boundaryEventBehavior.getClass(), boundaryEventExecution.getId());


### PR DESCRIPTION
boundaryEvents's and boundaryEventExecutions's size is mismatch

#### Check List:
* Unit tests: YES / NO / NA
* Documentation: YES / NO / NA
